### PR TITLE
BUG: Fix Issue With Adding To Section Under Unreleased

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -50,7 +50,8 @@ describe("keepachangelog()", () => {
         modified_files: ["CHANGELOG.md"],
         diffForFile: jest.fn(() => {
           return Promise.resolve({
-            added: "+- Translation.\n+"
+            added: "+- Translation.\n+",
+            after: "- Translation.\n"
           });
         })
       },
@@ -70,7 +71,8 @@ describe("keepachangelog()", () => {
         modified_files: ["CHANGELOG.md"],
         diffForFile: jest.fn(() => {
           return Promise.resolve({
-            added: "+## [1.0.1] - 2020-03-20\n+- Translation.\n+"
+            added: "+## [1.0.1] - 2020-03-20\n+- Translation.\n+",
+            after: "## [1.0.1] - 2020-03-20\n- Translation.\n"
           });
         })
       },
@@ -84,13 +86,35 @@ describe("keepachangelog()", () => {
     expect(global.fail).toHaveBeenCalledWith(noSection(true), "CHANGELOG.md");
   });
 
+  it("pass if the entry is contained in a section", async () => {
+    global.danger = {
+      git: {
+        modified_files: ["CHANGELOG.md"],
+        diffForFile: jest.fn(() => {
+          return Promise.resolve({
+            added: "+- Translation.\n+",
+            after: "## [Unreleased]\n### Fixed\n- Issue with image sizing in the SKU Selector.\n- Translation.\n"
+          });
+        })
+      },
+      github: {
+        pr: { title: "title", body: "body" }
+      }
+    };
+
+    await keepachangelog({ changeVersion: false });
+
+    expect(global.fail).not.toHaveBeenCalled();
+  });
+
   it("fail if there's version change when versionLine option is false", async () => {
     global.danger = {
       git: {
         modified_files: ["CHANGELOG.md"],
         diffForFile: jest.fn(() => {
           return Promise.resolve({
-            added: "+## [1.0.1] - 2020-03-20\n+### Fixed\n+- Translation.\n+"
+            added: "+## [1.0.1] - 2020-03-20\n+### Fixed\n+- Translation.\n+",
+            after: "## [1.0.1] - 2020-03-20\n### Fixed\n- Translation.\n"
           });
         })
       },


### PR DESCRIPTION
This fixes #1 where adding an entry to an existing section under `## [Unreleased]` is seen as not having added an entry to the changelog.

This changes the logic to check if a log entry has been added by scanning upwards in the changelog from each changed line looking for a section header. If no section header is found or if a version header is found then that means that the changed line isn't under a section and therefore isn't properly formatted in the changelog.

A new test case is added which has an entry added to an existing section to test the new functionality and that would fail without it. Existing tests are also updated with extra mock information that the new logic requires.